### PR TITLE
Initialize FastAPI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+database.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# Duff
+# Duff Digital Product Passport
+
+This repository contains a minimal FastAPI application that provides a simple
+"digital product passport" API. Products can be registered with basic
+information such as materials, manufacturing location, supply chain history, and
+recycling details. The data is stored in a local SQLite database using
+[SQLModel](https://sqlmodel.tiangolo.com/).
+
+## Requirements
+
+- Python 3.12+
+- Dependencies listed in `requirements.txt`
+
+Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the App
+
+```bash
+uvicorn src.app:app --reload
+```
+
+This starts the API server at `http://localhost:8000`.
+
+## Tests
+
+Run the tests with:
+
+```bash
+pytest
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlmodel
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI, HTTPException, Depends
+from sqlmodel import Session, select
+from .models import Product
+from .database import init_db, get_session
+
+app = FastAPI(title="Duff Digital Product Passport")
+
+init_db()
+
+
+@app.post("/products", response_model=Product)
+def create_product(product: Product, session: Session = Depends(get_session)):
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+    return product
+
+
+@app.get("/products/{product_id}", response_model=Product)
+def read_product(product_id: int, session: Session = Depends(get_session)):
+    product = session.get(Product, product_id)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product
+
+
+@app.put("/products/{product_id}", response_model=Product)
+def update_product(product_id: int, data: Product, session: Session = Depends(get_session)):
+    db_product = session.get(Product, product_id)
+    if not db_product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    for field, value in data.dict(exclude_unset=True).items():
+        setattr(db_product, field, value)
+    session.add(db_product)
+    session.commit()
+    session.refresh(db_product)
+    return db_product
+
+
+@app.get("/products", response_model=list[Product])
+def list_products(session: Session = Depends(get_session)):
+    products = session.exec(select(Product)).all()
+    return products

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,12 @@
+from sqlmodel import SQLModel, create_engine, Session
+
+DATABASE_URL = "sqlite:///./database.db"
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+def init_db():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    return Session(engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,10 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+
+class Product(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    material: str
+    manufacturing_place: str
+    supply_chain_history: str
+    recycling_info: str

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from src.app import app
+
+client = TestClient(app)
+
+def test_create_and_read_product():
+    payload = {
+        "name": "Test Product",
+        "material": "Steel",
+        "manufacturing_place": "Factory A",
+        "supply_chain_history": "Supplier X > Factory A",
+        "recycling_info": "Recycle at Center B"
+    }
+    response = client.post("/products", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] > 0
+    product_id = data["id"]
+
+    get_resp = client.get(f"/products/{product_id}")
+    assert get_resp.status_code == 200
+    read_data = get_resp.json()
+    assert read_data["name"] == payload["name"]


### PR DESCRIPTION
## Summary
- initialize project with FastAPI and SQLModel
- provide CRUD endpoints for product passports
- add simple test for API
- document setup and usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842787689f88329b8782019763c7cbe