### PR TITLE
Initialize FastAPI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+database.db

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ uvicorn src.app:app --reload
 
 This starts the API server at `http://localhost:8000`.
 
+Open that URL in your browser to access a simple front-end. The page lets you
+add products and lists the existing ones by calling the API.
+
 ## Tests
 
 Run the tests with:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# Duff
+# Duff Digital Product Passport
+
+This repository contains a minimal FastAPI application that provides a simple
+"digital product passport" API. Products can be registered with basic
+information such as materials, manufacturing location, supply chain history, and
+recycling details. The data is stored in a local SQLite database using
+[SQLModel](https://sqlmodel.tiangolo.com/).
+
+## Requirements
+
+- Python 3.12+
+- Dependencies listed in `requirements.txt`
+
+Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the App
+
+```bash
+uvicorn src.app:app --reload
+```
+
+This starts the API server at `http://localhost:8000`.
+
+## Tests
+
+Run the tests with:
+
+```bash
+pytest
+```
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ uvicorn src.app:app --reload
 This starts the API server at `http://localhost:8000`.
 
 Open that URL in your browser to access a simple front-end. The page lets you
-add products and lists the existing ones by calling the API.
+add products and lists the existing ones by calling the API. It also lets you
+create supplier requests and escalate them across tiers if unanswered. Each
+escalation generates a new tracking URL which is shown in the request list.
 
 ## Tests
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -29,3 +29,36 @@ document.getElementById('product-form').addEventListener('submit', async (e) => 
 });
 
 fetchProducts();
+
+async function fetchRequests() {
+  const res = await fetch('/requests');
+  const requests = await res.json();
+  const list = document.getElementById('requests');
+  list.innerHTML = '';
+  requests.forEach(r => {
+    const li = document.createElement('li');
+    const urls = r.urls.map(u => `<a href="/requests/${r.id}?url=${u.url}">${u.url}</a>`).join(', ');
+    li.innerHTML = `#${r.id} (tier ${r.tier}) - ${r.content} - URLs: ${urls} <button data-id="${r.id}">Escalate</button>`;
+    list.appendChild(li);
+  });
+  document.querySelectorAll('#requests button').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      await fetch(`/requests/${btn.dataset.id}/escalate`, { method: 'POST' });
+      fetchRequests();
+    });
+  });
+}
+
+document.getElementById('request-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = { content: document.getElementById('content').value };
+  await fetch('/requests', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  e.target.reset();
+  fetchRequests();
+});
+
+fetchRequests();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,31 @@
+async function fetchProducts() {
+  const res = await fetch('/products');
+  const products = await res.json();
+  const list = document.getElementById('products');
+  list.innerHTML = '';
+  products.forEach(p => {
+    const li = document.createElement('li');
+    li.textContent = `${p.id}: ${p.name} (${p.material})`;
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('product-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    name: document.getElementById('name').value,
+    material: document.getElementById('material').value,
+    manufacturing_place: document.getElementById('manufacturing_place').value,
+    supply_chain_history: document.getElementById('supply_chain_history').value,
+    recycling_info: document.getElementById('recycling_info').value
+  };
+  await fetch('/products', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  e.target.reset();
+  fetchProducts();
+});
+
+fetchProducts();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,13 @@
   </form>
   <h2>Products</h2>
   <ul id="products"></ul>
-<script src="app.js"></script>
+
+  <h2>Supplier Requests</h2>
+  <form id="request-form">
+    <input type="text" id="content" placeholder="Request content" required>
+    <button type="submit">Create request</button>
+  </form>
+  <ul id="requests"></ul>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Duff Digital Product Passport</title>
+</head>
+<body>
+  <h1>Duff Digital Product Passport</h1>
+  <form id="product-form">
+    <input type="text" id="name" placeholder="Name" required>
+    <input type="text" id="material" placeholder="Material" required>
+    <input type="text" id="manufacturing_place" placeholder="Manufacturing place" required>
+    <input type="text" id="supply_chain_history" placeholder="Supply chain history" required>
+    <input type="text" id="recycling_info" placeholder="Recycling info" required>
+    <button type="submit">Add product</button>
+  </form>
+  <h2>Products</h2>
+  <ul id="products"></ul>
+<script src="app.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlmodel
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI, HTTPException, Depends
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
 from sqlmodel import Session, select
 from .models import Product
 from .database import init_db, get_session
@@ -6,6 +8,13 @@ from .database import init_db, get_session
 app = FastAPI(title="Duff Digital Product Passport")
 
 init_db()
+
+app.mount("/frontend", StaticFiles(directory="frontend", html=True), name="frontend")
+
+
+@app.get("/")
+def root():
+    return RedirectResponse(url="/frontend")
 
 
 @app.post("/products", response_model=Product)

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI, HTTPException, Depends
+from sqlmodel import Session, select
+from .models import Product
+from .database import init_db, get_session
+
+app = FastAPI(title="Duff Digital Product Passport")
+
+init_db()
+
+
+@app.post("/products", response_model=Product)
+def create_product(product: Product, session: Session = Depends(get_session)):
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+    return product
+
+
+@app.get("/products/{product_id}", response_model=Product)
+def read_product(product_id: int, session: Session = Depends(get_session)):
+    product = session.get(Product, product_id)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product
+
+
+@app.put("/products/{product_id}", response_model=Product)
+def update_product(product_id: int, data: Product, session: Session = Depends(get_session)):
+    db_product = session.get(Product, product_id)
+    if not db_product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    for field, value in data.dict(exclude_unset=True).items():
+        setattr(db_product, field, value)
+    session.add(db_product)
+    session.commit()
+    session.refresh(db_product)
+    return db_product
+
+
+@app.get("/products", response_model=list[Product])
+def list_products(session: Session = Depends(get_session)):
+    products = session.exec(select(Product)).all()
+    return products

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException, Depends
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from sqlmodel import Session, select
-from .models import Product
+from .models import Product, Request, RequestURL, RequestCreate, RequestRead, RequestURLRead
 from .database import init_db, get_session
 
 app = FastAPI(title="Duff Digital Product Passport")
@@ -50,3 +50,40 @@ def update_product(product_id: int, data: Product, session: Session = Depends(ge
 def list_products(session: Session = Depends(get_session)):
     products = session.exec(select(Product)).all()
     return products
+
+
+@app.post("/requests", response_model=RequestRead)
+def create_request(data: RequestCreate, session: Session = Depends(get_session)):
+    req = Request(content=data.content)
+    session.add(req)
+    session.commit()
+    session.refresh(req)
+    url = RequestURL(request_id=req.id, tier=1)
+    session.add(url)
+    session.commit()
+    session.refresh(req)
+    return req
+
+
+@app.post("/requests/{request_id}/escalate", response_model=RequestURLRead)
+def escalate_request(request_id: int, session: Session = Depends(get_session)):
+    req = session.get(Request, request_id)
+    if not req:
+        raise HTTPException(status_code=404, detail="Request not found")
+    if req.tier >= 3:
+        raise HTTPException(status_code=400, detail="Already at highest tier")
+    req.tier += 1
+    url = RequestURL(request_id=req.id, tier=req.tier)
+    session.add(url)
+    session.add(req)
+    session.commit()
+    session.refresh(url)
+    return url
+
+
+@app.get("/requests", response_model=list[RequestRead])
+def list_requests(session: Session = Depends(get_session)):
+    requests = session.exec(select(Request)).all()
+    for r in requests:
+        r.urls  # triggers loading of relationship
+    return requests

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,12 @@
+from sqlmodel import SQLModel, create_engine, Session
+
+DATABASE_URL = "sqlite:///./database.db"
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+def init_db():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    return Session(engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,10 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+
+class Product(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    material: str
+    manufacturing_place: str
+    supply_chain_history: str
+    recycling_info: str

--- a/src/models.py
+++ b/src/models.py
@@ -1,5 +1,7 @@
-from sqlmodel import SQLModel, Field
-from typing import Optional
+from sqlmodel import SQLModel, Field, Relationship
+from typing import Optional, List
+from uuid import uuid4
+from datetime import datetime
 
 class Product(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -8,3 +10,37 @@ class Product(SQLModel, table=True):
     manufacturing_place: str
     supply_chain_history: str
     recycling_info: str
+
+
+class RequestURL(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    request_id: int = Field(foreign_key="request.id")
+    url: str = Field(default_factory=lambda: str(uuid4()))
+    tier: int
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    request: Optional["Request"] = Relationship(back_populates="urls")
+
+
+class Request(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    content: str
+    tier: int = 1
+    urls: List[RequestURL] = Relationship(back_populates="request")
+
+
+class RequestCreate(SQLModel):
+    content: str
+
+
+class RequestURLRead(SQLModel):
+    id: int
+    url: str
+    tier: int
+    created_at: datetime
+
+
+class RequestRead(SQLModel):
+    id: int
+    content: str
+    tier: int
+    urls: List[RequestURLRead] = []

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from src.app import app
+
+client = TestClient(app)
+
+def test_create_and_read_product():
+    payload = {
+        "name": "Test Product",
+        "material": "Steel",
+        "manufacturing_place": "Factory A",
+        "supply_chain_history": "Supplier X > Factory A",
+        "recycling_info": "Recycle at Center B"
+    }
+    response = client.post("/products", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] > 0
+    product_id = data["id"]
+
+    get_resp = client.get(f"/products/{product_id}")
+    assert get_resp.status_code == 200
+    read_data = get_resp.json()
+    assert read_data["name"] == payload["name"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,3 +26,24 @@ def test_create_and_read_product():
     assert get_resp.status_code == 200
     read_data = get_resp.json()
     assert read_data["name"] == payload["name"]
+
+
+def test_request_escalation():
+    payload = {"content": "Need material certificate"}
+    resp = client.post("/requests", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tier"] == 1
+    assert len(data["urls"]) == 1
+    request_id = data["id"]
+
+    esc = client.post(f"/requests/{request_id}/escalate")
+    assert esc.status_code == 200
+    url_data = esc.json()
+    assert url_data["tier"] == 2
+
+    list_resp = client.get("/requests")
+    assert list_resp.status_code == 200
+    list_data = list_resp.json()
+    match = next(r for r in list_data if r["id"] == request_id)
+    assert len(match["urls"]) == 2


### PR DESCRIPTION
## Summary
- initialize project with FastAPI and SQLModel
- provide CRUD endpoints for product passports
- add simple test for API
- document setup and usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842787689f88329b8782019763c7cbe